### PR TITLE
mongodb now initialises with an authorised user

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -15,12 +15,20 @@ const koaBody = require("koa-body")({
 });
 const loggedInUserService = require("./services/LoggedInUserService");
 
-mongoose.Promise = Promise;
-const mongoUri = `mongodb://${config.get("mongodb.host")}:${config.get("mongodb.port")}/${config.get(
-  "mongodb.database"
-)}`;
+let dbSecret = config.get("mongodb.secret");
+if (typeof dbSecret === "string") {
+  dbSecret = JSON.parse(dbSecret);
+}
 
-mongoose.connect(mongoUri, err => {
+const mongoURL =
+  "mongodb://" +
+  `${dbSecret.username}:${dbSecret.password}` +
+  `@${config.get("mongodb.host")}:${config.get("mongodb.port")}` +
+  `/${config.get("mongodb.database")}`;
+
+mongoose.Promise = Promise;
+
+mongoose.connect(mongoURL, err => {
   if (err) {
     logger.error(err);
     throw new Error(err);

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -3,7 +3,9 @@
     "port": "PORT"
   },
   "mongodb": {
-    "host": "MONGO_PORT_27017_TCP_ADDR"
+    "database": "DB_DATABASE",
+    "host": "MONGO_PORT_27017_TCP_ADDR",
+    "secret": "DB_SECRET"
   },
   "teamsAPI": {
     "url": "TEAMS_API_URL"

--- a/data/mongo/001_users.js
+++ b/data/mongo/001_users.js
@@ -1,0 +1,10 @@
+db.createUser({
+  user: "admin",
+  pwd: "password",
+  roles: [
+    {
+      role: "readWrite",
+      db: "fw_contextual_layer"
+    }
+  ]
+});

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -14,6 +14,8 @@ services:
       LOCAL_URL: http://127.0.0.1:3025
       TEAMS_API_URL: http://fw-teams-develop:3035/api/v1
       MONGO_PORT_27017_TCP_ADDR: mongo
+      DB_SECRET: '{ "username": "admin", "password": "password" }'
+      DB_DATABASE: fw_contextual_layer
       API_VERSION: v1
     volumes:
       - ./app:/opt/fw-contextual-layer/app
@@ -30,11 +32,20 @@ services:
     command: --smallfiles
     ports:
       - "27023:27017"
+    environment:
+      MONGO_INITDB_DATABASE: fw_contextual_layer
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
     volumes:
-      - $HOME/docker/data/fw-contextual-layer:/data/db
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - fw-contextual-layer-mongodb-data:/data/db
     restart: always
     networks:
       - gfw-contextual-layers-network
+
+volumes:
+  fw-contextual-layer-mongodb-data:
+
 networks:
   gfw-network:
     name: gfw-network

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,6 +14,8 @@ services:
       LOCAL_URL: http://127.0.0.1:3025
       TEAMS_API_URL: http://fw-teams-develop:3035/api/v1
       MONGO_PORT_27017_TCP_ADDR: mongo
+      DB_SECRET: '{ "username": "admin", "password": "password" }'
+      DB_DATABASE: fw_contextual_layer
       API_VERSION: v1
     depends_on:
       - mongo
@@ -24,3 +26,13 @@ services:
     command: --smallfiles
     ports:
       - "27017"
+    environment:
+      MONGO_INITDB_DATABASE: fw_contextual_layer
+      MONGO_INITDB_ROOT_PASSWORD: password
+      MONGO_INITDB_ROOT_USERNAME: admin
+    volumes:
+      - ./data/mongo/001_users.js:/docker-entrypoint-initdb.d/001_users.js:ro
+      - fw-contextual-layer-mongodb-data:/data/db
+
+volumes:
+  fw-contextual-layer-mongodb-data:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -76,6 +76,7 @@ data "template_file" "container_definition" {
     LOCAL_URL                 = "http://127.0.0.1:${var.container_port}"
     TEAMS_API_URL             = "http://${data.terraform_remote_state.fw_core.outputs.public_url}/api/v1"
     MONGO_PORT_27017_TCP_ADDR = data.terraform_remote_state.core.outputs.document_db_endpoint
+    db_secret_arn             = data.terraform_remote_state.core.outputs.document_db_secrets_arn
     API_VERSION               = var.API_VERSION
   }
 }

--- a/terraform/templates/container_definition.json.tmpl
+++ b/terraform/templates/container_definition.json.tmpl
@@ -36,7 +36,12 @@
       "value": "${API_VERSION}"
     }
   ],
-  "secrets": [],
+  "secrets": [
+    {
+      "name": "DB_SECRET",
+      "valueFrom": "${db_secret_arn}"
+    }
+  ],
   "portMappings": [
     {
       "containerPort": ${container_port},


### PR DESCRIPTION
Now locally when the MongoDB is initialised an admin user is created, following the technique described https://github.com/docker-library/mongo/issues/174#issuecomment-449984230 and [here](https://dev.to/emmysteven/how-not-to-configure-mongodb-on-docker-nbn). This is to mimic the behaviour on production.

The local MongoDB data is now sorted in a named volume so it's easier to work with locally! e.g. docker volume rm gfw-forms-mongodb-data

DB_SECRET is provided by terraform in dev, staging and production environments, although this wasn't used in the code base.

Locally this is now replicated. Once DB_SECRET in parsed the database's "username" and "password" key value pairs are available locally and in production. 